### PR TITLE
Update actions/setup-python v4 -> v5

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -14,7 +14,7 @@ jobs:
     - uses: actions/checkout@v4
     
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: '3.12'
     


### PR DESCRIPTION
Found by an org-wide [actionlint](https://github.com/rhysd/actionlint) sweep. Per review feedback the lint tooling itself is staying in the core repos (compiler-explorer, infra, compiler-workflows) — this PR keeps just the fixes, which stand on their own:

- actions/setup-python v4 -> v5

🤖 Generated with [Claude Code](https://claude.com/claude-code)